### PR TITLE
Use resourceGitlabGroupMembershipUpdate for both create and update

### DIFF
--- a/internal/provider/sdk/resource_gitlab_group_membership.go
+++ b/internal/provider/sdk/resource_gitlab_group_membership.go
@@ -23,7 +23,7 @@ var _ = registerResource("gitlab_group_membership", func() *schema.Resource {
 
 **Upstream API**: [GitLab REST API docs](https://docs.gitlab.com/ee/api/members.html)`,
 
-		CreateContext: resourceGitlabGroupMembershipCreate,
+		CreateContext: resourceGitlabGroupMembershipUpdate,
 		ReadContext:   resourceGitlabGroupMembershipRead,
 		UpdateContext: resourceGitlabGroupMembershipUpdate,
 		DeleteContext: resourceGitlabGroupMembershipDelete,


### PR DESCRIPTION
This PR handles the case where a membership already exists (e.g. manually added member).

Previously, we get an HTTP error 409. Now we don't get that error and the create operation is idempotent.

Related issue:
https://gitlab.com/gitlab-org/terraform-provider-gitlab/-/issues/993

GitHub provider's implementation (the inspiration for this PR):
https://github.com/integrations/terraform-provider-github/blob/f2aacaf90d290cc1826daec0dbed80f4a79c7657/github/resource_github_membership.go#L43

